### PR TITLE
Fix module (mjs) export

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,14 @@
     "primitive"
   ],
   "main": "decimalish.js",
-  "module": "decimalish.mjs",
   "types": "decimalish.d.ts",
+  "exports": {
+    ".": {
+      "types": "./decimalish.d.ts",
+      "import": "./decimalish.mjs",
+      "require": "./decimalish.js"
+    }
+  },
   "sideEffects": false,
   "--exclude-from-npm-publish-below-this-line--": true,
   "scripts": {


### PR DESCRIPTION
Currently, the mjs export doesn't really work. It is never consumed by user code, as it relies on undocumented/obsolete `module` field:

https://github.com/leebyron/decimalish/blob/754a370840752374211f9dec946fd9bcd716e426/package.json#L34-L36

One can check that by adding `console.log` to `decimalish.js` and `decimalish.mjs` and calling it:

```
% node -e 'const { decimal } = require("decimalish"); decimal(1)'
cjs decimal
% node -e 'import { decimal } from "decimalish"; decimal(1)'     
cjs decimal
```

with the fix, it becomes:

```
% node -e 'const { decimal } = require("decimalish"); decimal(1)'
cjs decimal
% node -e 'import { decimal } from "decimalish"; decimal(1)'     
mjs decimal
```

It's worth noting that the `types` has also never been standardized, although it was a widely supported convention for the time. Nowadays, all modern tooling uses `exports` → `types` as the source of truth (and it [must go first](https://nodejs.org/api/packages.html#community-conditions-definitions) in the list).